### PR TITLE
Add and define code-style rules in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,219 @@
+root = true
+
+# default settings:
+[*]
+insert_final_newline = true
+indent_style = space
+charset = utf-8
+trim_trailing_whitespace = true
+max_line_length = 130
+
+# C# files
+[*.cs]
+indent_size = 4
+
+# new line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+
+# modifier preferences
+csharp_preferred_modifier_order = public, private, protected, internal, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, volatile, async:suggestion
+
+# avoid  unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# types: use keywords instead of BCL types, and permit var only when the type is clear
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = false:none
+csharp_style_var_elsewhere = false:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# define a style called 'pascal_case_style' that enforces pascal casing
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# define a style called 'camel_case_underscore_style' that enforces camel casing with prefix _Underscore
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
+dotnet_naming_style.camel_case_underscore_style.required_prefix = _
+
+# name all constant fields using PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+
+# public static fields should be PascalCase
+dotnet_naming_symbols.public_static_fields.applicable_kinds = field
+dotnet_naming_symbols.public_static_fields.applicable_accessibilities = public, protected, internal, protected_internal
+dotnet_naming_symbols.public_static_fields.required_modifiers = static
+dotnet_naming_rule.public_static_fields_should_have_prefix.severity = suggestion
+dotnet_naming_rule.public_static_fields_should_have_prefix.symbols = public_static_fields
+dotnet_naming_rule.public_static_fields_should_have_prefix.style = pascal_case_style
+
+# private static fields should be _camelCase
+dotnet_naming_symbols.private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_fields.required_modifiers = static
+dotnet_naming_rule.private_static_fields_should_have_prefix.severity = suggestion
+dotnet_naming_rule.private_static_fields_should_have_prefix.symbols = private_static_fields
+dotnet_naming_rule.private_static_fields_should_have_prefix.style = camel_case_underscore_style
+
+# internal and private fields should be _camelCase
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style = camel_case_underscore_style
+dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+
+# code style defaults
+dotnet_sort_system_directives_first = true
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = false
+csharp_prefer_braces = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_using_directive_placement = outside_namespace:suggestion
+csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_simple_using_statement = true
+csharp_style_prefer_switch_expression = true:suggestion
+dotnet_style_readonly_field = true:suggestion
+
+# expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+csharp_prefer_simple_default_expression = true:suggestion
+
+# expression-bodied members
+csharp_style_expression_bodied_methods = true:silent
+csharp_style_expression_bodied_constructors = true:silent
+csharp_style_expression_bodied_operators = true:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = true:silent
+
+# pattern matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# null checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# other features
+csharp_style_prefer_index_operator = false:none
+csharp_style_prefer_range_operator = false:none
+csharp_style_pattern_local_over_anonymous_function = false:none
+
+# space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# diagnostic preferences
+dotnet_diagnostic.CA1018.severity = warning # CA1018: Mark attributes with AttributeUsageAttribute
+dotnet_diagnostic.CA1047.severity = warning # CA1047: Do not declare protected member in sealed type
+dotnet_diagnostic.CA1507.severity = warning # CA1507: Use nameof to express symbol names
+dotnet_diagnostic.CA1725.severity = suggestion # CA1725: Parameter names should match base declaration
+dotnet_diagnostic.CA1805.severity = warning # CA1805: Do not initialize unnecessarily
+dotnet_diagnostic.CA1810.severity = warning # CA1810: Do not initialize unnecessarily
+dotnet_diagnostic.CA1821.severity = warning # CA1821: Remove empty Finalizers
+dotnet_diagnostic.CA1822.severity = warning # CA1822: Make member static
+dotnet_code_quality.CA1822.api_surface = private, internal
+dotnet_diagnostic.CA1823.severity = warning # CA1823: Avoid unused private fields
+dotnet_diagnostic.CA1825.severity = warning # CA1825: Avoid zero-length array allocations
+dotnet_diagnostic.CA1826.severity = warning # CA1826: Do not use Enumerable methods on indexable collections. Instead use the collection directly
+dotnet_diagnostic.CA1827.severity = warning # CA1827: Do not use Count() or LongCount() when Any() can be used
+dotnet_diagnostic.CA1828.severity = warning # CA1828: Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+dotnet_diagnostic.CA1829.severity = warning # CA1829: Use Length/Count property instead of Count() when available
+dotnet_diagnostic.CA1830.severity = warning # CA1830: Prefer strongly-typed Append and Insert method overloads on StringBuilder
+dotnet_diagnostic.CA1831.severity = warning # CA1831: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+dotnet_diagnostic.CA1832.severity = warning # CA1832: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+dotnet_diagnostic.CA1833.severity = warning # CA1833: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+dotnet_diagnostic.CA1834.severity = warning # CA1834: Consider using 'StringBuilder.Append(char)' when applicable
+dotnet_diagnostic.CA1835.severity = warning # CA1835: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+dotnet_diagnostic.CA1836.severity = warning # CA1836: Prefer IsEmpty over Count
+dotnet_diagnostic.CA1840.severity = warning # CA1840: Use 'Environment.CurrentManagedThreadId'
+dotnet_diagnostic.CA1841.severity = warning # CA1841: Prefer Dictionary.Contains methods
+dotnet_diagnostic.CA1842.severity = warning # CA1842: Do not use 'WhenAll' with a single task
+dotnet_diagnostic.CA1843.severity = warning # CA1843: Do not use 'WaitAll' with a single task
+dotnet_diagnostic.CA1845.severity = warning # CA1845: Use span-based 'string.Concat'
+dotnet_diagnostic.CA1846.severity = warning # CA1846: Prefer AsSpan over Substring
+dotnet_diagnostic.CA1847.severity = warning # CA1847: Use string.Contains(char) instead of string.Contains(string) with single characters
+dotnet_diagnostic.CA2009.severity = warning # CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
+dotnet_diagnostic.CA2012.severity = warning # CA2012: Use ValueTask correctly
+dotnet_diagnostic.CA2245.severity = warning # CA2245: Do not assign a property to itself
+dotnet_diagnostic.CA2208.severity = warning # CA2208: Instantiate argument exceptions correctly
+dotnet_diagnostic.CA2249.severity = warning # CA2249: Use string.Contains instead of string.IndexOf to improve readability.
+dotnet_diagnostic.IDE0005.severity = warning # IDE0005: Remove unnecessary usings
+dotnet_diagnostic.IDE0043.severity = warning # IDE0043: Format string contains invalid placeholder
+
+dotnet_style_allow_multiple_blank_lines_experimental = false # IDE2000: Disallow multiple blank lines
+dotnet_diagnostic.IDE2000.severity = warning
+
+[*.{xml,config,*proj,nuspec,props,resx,targets,yml,tasks}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+[*.json]
+indent_size = 2
+
+[*.{ps1,psm1}]
+indent_size = 4
+
+[*.sh]
+indent_size = 4
+end_of_line = lf
+
+[*.{razor,cshtml}]
+charset = utf-8-bom
+
+[*.{cs,vb}]


### PR DESCRIPTION
I've initiated the process of integrating and refining our .editorconfig to align with the code-style rules recommended by Microsoft and the broader .NET community. This action aims to enhance consistency and maintainability across our codebase, leveraging best practices from notable .NET repositories like dotnet/runtime, dotnet/aspnetcore, and dotnet/efcore.

**Your Feedback is Crucial:** Before we finalize and enforce these configurations, I highly encourage everyone to review the proposed .editorconfig, and share any feedback or suggestions. Your insights are invaluable in ensuring that our coding standards meet our collective needs and preferences.